### PR TITLE
Persist session playback progress

### DIFF
--- a/global-player.js
+++ b/global-player.js
@@ -477,6 +477,9 @@ class GlobalAudioPlayer {
             const percent = (this.audio.currentTime / this.audio.duration) * 100;
             this.progressFill.style.width = percent + '%';
             this.currentTimeEl.textContent = this.formatTime(this.audio.currentTime);
+
+            // Persist progress
+            this.saveToStorage();
         }
     }
 

--- a/player.html
+++ b/player.html
@@ -874,6 +874,20 @@
             
             // Load audio
             const audio = document.getElementById('mainAudioPlayer');
+
+            // Restore progress from localStorage if available
+            try {
+                const saved = JSON.parse(localStorage.getItem('sessionProgress') || '{}');
+                if (saved.id === sessionId) {
+                    audio.addEventListener('loadedmetadata', () => {
+                        if (!isNaN(audio.duration)) {
+                            audio.currentTime = Math.min(saved.currentTime || 0, audio.duration);
+                        }
+                    });
+                }
+            } catch (e) {
+                console.warn('Could not load session progress:', e);
+            }
             
             // Add error handling for audio loading
             audio.addEventListener('error', function(e) {
@@ -1052,6 +1066,16 @@
                 }
                 if (!isNaN(audio.currentTime)) {
                     currentTimeEl.textContent = formatTime(audio.currentTime);
+                }
+
+                // Save progress to localStorage
+                try {
+                    localStorage.setItem('sessionProgress', JSON.stringify({
+                        id: sessionId,
+                        currentTime: audio.currentTime
+                    }));
+                } catch (e) {
+                    console.warn('Could not save session progress:', e);
                 }
             });
 


### PR DESCRIPTION
## Summary
- restore playback position when reopening player page
- persist progress as audio plays
- keep global player current time in storage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889fcda3f7883249852cf6aff6a41e0