### PR TITLE
Fix mobile player sync and volume

### DIFF
--- a/global-player.js
+++ b/global-player.js
@@ -22,8 +22,16 @@ class GlobalAudioPlayer {
     setAudioElement(audioEl) {
         if (!audioEl) return;
 
-        // Stop and detach any previous audio element
+        // Preserve state of previous element
+        let wasPlaying = false;
+        let currentTime = 0;
+        let volume = 1;
+
         if (this.audio && this.audio !== audioEl) {
+            wasPlaying = !this.audio.paused;
+            currentTime = this.audio.currentTime;
+            volume = this.audio.volume;
+
             try {
                 this.audio.pause();
             } catch (e) {
@@ -32,7 +40,13 @@ class GlobalAudioPlayer {
         }
 
         this.audio = audioEl;
+        this.audio.currentTime = currentTime;
+        this.audio.volume = volume;
         this.setupAudioEventListeners();
+
+        if (wasPlaying) {
+            this.audio.play().catch(e => console.warn('Sync play failed', e));
+        }
 
         this.updateMediaSession();
     }

--- a/player.html
+++ b/player.html
@@ -14,7 +14,7 @@
     
     <!-- Navigation -->
     <nav class="player-nav">
-        <a href="javascript:history.back()" class="nav-back">← Volver</a>
+        <a href="#" onclick="history.back(); return false;" class="nav-back">← Volver</a>
     </nav>
     
     <!-- Parallax Background Elements -->
@@ -83,7 +83,7 @@
                                             <path d="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.85 14,18.71V20.77C18.01,19.86 21,16.28 21,12C21,7.72 18.01,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z"/>
                                         </svg>
                                     </button>
-                                    <input type="range" class="volume-slider volume-slider-vertical" id="volumeSlider" min="0" max="1" step="0.01" value="1" orient="vertical">
+                                    <input type="range" class="volume-slider volume-slider-vertical" id="playerVolumeSlider" min="0" max="1" step="0.01" value="1" orient="vertical">
                                 </div>
                                 
                                 <div class="time-display">
@@ -848,7 +848,7 @@
                                         <path d="M14,3.23V5.29C16.89,6.15 19,8.83 19,12C19,15.17 16.89,17.85 14,18.71V20.77C18.01,19.86 21,16.28 21,12C21,7.72 18.01,4.14 14,3.23M16.5,12C16.5,10.23 15.5,8.71 14,7.97V16C15.5,15.29 16.5,13.76 16.5,12M3,9V15H7L12,20V4L7,9H3Z"/>
                                     </svg>
                                 </button>
-                                <input type="range" class="volume-slider volume-slider-vertical" id="volumeSlider" min="0" max="1" step="0.01" value="1" orient="vertical">
+                                <input type="range" class="volume-slider volume-slider-vertical" id="playerVolumeSlider" min="0" max="1" step="0.01" value="1" orient="vertical">
                             </div>
                             <div class="time-display">
                                 <span id="currentTime">00:00</span> / <span id="totalTime">00:00</span>
@@ -973,7 +973,7 @@
             const progressHandle = document.getElementById('progressHandle');
             const currentTimeEl = document.getElementById('currentTime');
             const totalTimeEl = document.getElementById('totalTime');
-            const volumeSlider = document.getElementById('volumeSlider');
+            const volumeSlider = document.getElementById('playerVolumeSlider');
             const volumeControl = document.getElementById('playerVolumeControl');
             const playIcon = document.querySelector('.play-icon');
             const pauseIcon = document.querySelector('.pause-icon');
@@ -989,7 +989,9 @@
             };
 
             if (window.globalAudioPlayer) {
+                window.globalAudioPlayer.currentSession = window.currentSessionData;
                 window.globalAudioPlayer.setAudioElement(audio);
+                window.globalAudioPlayer.updateMediaSession();
             }
 
             volumeSlider.addEventListener('input', (e) => {


### PR DESCRIPTION
## Summary
- toggle back button with safer handler
- prevent ID collision for volume slider and sync metadata
- preserve playback state when switching audio element

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889d26e02e48324bc7affc8c8d532f6