### PR TITLE
Add MIME detection for audio sources

### DIFF
--- a/player.html
+++ b/player.html
@@ -801,9 +801,25 @@
                 `;
             } else {
                 // Reproductor estándar
+                const getMimeType = (url) => {
+                    if (!url) return 'audio/mpeg';
+                    const ext = url.split('.').pop().toLowerCase().split('?')[0];
+                    switch (ext) {
+                        case 'flac':
+                            return 'audio/flac';
+                        case 'wav':
+                            return 'audio/wav';
+                        default:
+                            return 'audio/mpeg';
+                    }
+                };
+                const mimeType = getMimeType(session.audioUrl);
+                const mp3Fallback = session.audioUrl.replace(/\.(flac|wav)(\?.*)?$/i, '.mp3');
+                const fallbackSource = mimeType !== 'audio/mpeg' ? `<source src="${mp3Fallback}" type="audio/mpeg">` : '';
                 audioContainer.innerHTML = `
                     <audio preload="none" id="mainAudioPlayer" aria-label="Reproductor principal de audio" crossorigin="anonymous">
-                        <source id="audioSource" src="${session.audioUrl}" type="audio/mpeg">
+                        <source id="audioSource" src="${session.audioUrl}" type="${mimeType}">
+                        ${fallbackSource}
                         Tu navegador no soporta el elemento de audio.
                     </audio>
                     <!-- Custom Player Controls -->


### PR DESCRIPTION
## Summary
- compute audio MIME type based on `session.audioUrl`
- include fallback MP3 source when needed

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688a618d59188324bbd26b649a1c621a